### PR TITLE
Fix bug pre-eXist 3.1.0

### DIFF
--- a/modules/lib/test-runner.xq
+++ b/modules/lib/test-runner.xq
@@ -190,7 +190,7 @@ let $getSequenceType := function( $node){
  else if ($node instance of comment()) then 'comment'
  else if ($node instance of processing-instruction())
          then 'processing-instruction'
- else if ($node instance of empty())
+ else if ($node instance of empty-sequence())
          then 'empty'
  else if ($node instance of item())
          then 'empty'


### PR DESCRIPTION
@grantmacken FYI, once https://github.com/eXist-db/exist/pull/1319 is merged, this change will be needed. The spec has always made `empty-sequence()` the sequence type check (in contrast to the function `empty()`), but a bug in eXist allowed `empty()` to be used as a sequence type check.